### PR TITLE
added digest argument to crypto.pbkdf2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ exports.generateKey = function (password, options, callback) {
 
     const generateKey = (salt) => {
 
-        Crypto.pbkdf2(password, salt, options.iterations, algorithm.keyBits / 8, (err, derivedKey) => {
+        Crypto.pbkdf2(password, salt, options.iterations, algorithm.keyBits / 8, 'sha1', (err, derivedKey) => {
 
             if (err) {
                 return callback(err);
@@ -416,4 +416,3 @@ exports.unseal = function (sealed, password, options, callback) {
         });
     });
 };
-

--- a/test/index.js
+++ b/test/index.js
@@ -275,7 +275,7 @@ describe('Iron', () => {
         it('returns an error when Crypto.pbkdf2 fails', (done) => {
 
             const orig = Crypto.pbkdf2;
-            Crypto.pbkdf2 = function (v1, v2, v3, v4, callback) {
+            Crypto.pbkdf2 = function (v1, v2, v3, v4, v5, callback) {
 
                 return callback(new Error('fake'));
             };


### PR DESCRIPTION
- it's an optional argument that in node 6 became non-optional
- also added 5th arg to mock Crypto.pbkdf2 in test

(I made the digest be the its default value in previous node versions (https://nodejs.org/dist/latest-v4.x/docs/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback) so the behaviour is unchanged)
