### PR TITLE
made exception message assertion less strict to account for different node 6 error message

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -499,7 +499,7 @@ describe('Iron', () => {
                     Iron.unseal(ticket, password, Iron.defaults, (err, unsealed) => {
 
                         expect(err).to.exist();
-                        expect(err.message).to.equal('Failed parsing sealed object JSON: Unexpected token a');
+                        expect(err.message).to.match(/Failed parsing sealed object JSON: Unexpected token a/);
                         done();
                     });
                 });


### PR DESCRIPTION
 node 6 has a more detailed error message for this error, which cause this test to fail