### PR TITLE
Catch and report possible `JSON.stringify` errors in `Iron.seal`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -264,7 +264,13 @@ exports.seal = function (object, password, options, callback) {
 
     // Serialize object
 
-    const objectString = JSON.stringify(object);
+    let objectString = '';
+    try {
+        objectString = JSON.stringify(object);
+    }
+    catch (error) {
+        return callbackTick(Boom.internal('Failed to stringify object: ' + error.message));
+    }
 
     // Obtain password
 

--- a/test/index.js
+++ b/test/index.js
@@ -115,6 +115,19 @@ describe('Iron', () => {
         });
     });
 
+    it('fails to turn object into a ticket (failed to stringify object)', (done) => {
+
+        const cyclic = [];
+        cyclic[0] = cyclic;
+        const key = Cryptiles.randomBits(128);
+        Iron.seal(cyclic, key, Iron.defaults, (err, sealed) => {
+
+            expect(err).to.exist();
+            expect(err.message).to.contain('Failed to stringify object');
+            done();
+        });
+    });
+
     it('turns object into a ticket than parses the ticket successfully (password object)', (done) => {
 
         Iron.seal(obj, { id: '1', secret: password }, Iron.defaults, (err, sealed) => {


### PR DESCRIPTION
`JSON.stringify` can throw a `TypeError` when it encounters a cyclic structure. I made `Iron.seal` catch these errors, so instead of blowing up synchronously it reports them to a provided `callback`.

This change mirrors `Iron.unseal` behavior, which reports `JSON.parse` errors.