### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ var obj = {
     }
 };
 
-var password = 'some_not_random_password';
+var password = 'some_not_random_password_that_is_at_least_32_characters';
 
 Iron.seal(obj, password, Iron.defaults, function (err, sealed) {
 


### PR DESCRIPTION
Make the example work. I used the same example and it printed `undefined` so I thought something was wrong. Turned out it was just the password.